### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Test/ClientServer.pm
+++ b/lib/Test/ClientServer.pm
@@ -1,4 +1,4 @@
-class Test::ClientServer:auth<github:flussence>:ver<2.0.0-pre.4>;
+unit class Test::ClientServer:auth<github:flussence>:ver<2.0.0-pre.4>;
 
 class X::Test::ClientServer is Exception {
     has Int $.timeout;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.